### PR TITLE
Change now.json example to include `.js` extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you're unfamiliar with now runtimes, please read the [runtime docs](https://z
 // now.json
 {
   "functions": {
-    "api/**/*.ts": {
+    "api/**/*.{j,t}s": {
       "runtime": "now-deno@0.2.0"
     }
   }


### PR DESCRIPTION
As deno also fully supports javascript we should recommend to add the js extension to the glob.