### PR TITLE
Use Context rather than APIGatewayEventRequestContext

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: ci
 
-on: push
+on: [push, pull_request]
 
 env:
   PACKAGE_NAME: '@now-deno/ci'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: ci
 
-on: [push, pull_request]
+on: push
 
 env:
   PACKAGE_NAME: '@now-deno/ci'

--- a/README.md
+++ b/README.md
@@ -21,9 +21,12 @@ If you're unfamiliar with now runtimes, please read the [runtime docs](https://z
 
 ```ts
 // api/hello.ts
-import { APIGatewayEventRequestContext, APIGatewayEvent } from 'https://deno.land/x/lambda/mod.ts';
+import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'https://deno.land/x/lambda/mod.ts';
 
-export async function handler(event: APIGatewayEvent, context: APIGatewayEventRequestContext) {
+export async function handler(
+  event: APIGatewayProxyEvent,
+  context: Context
+): Promise<APIGatewayProxyResult> {
   return {
     statusCode: 200,
     body: `Welcome to deno ${Deno.version.deno} 🦕`,

--- a/example/api/version.ts
+++ b/example/api/version.ts
@@ -1,12 +1,13 @@
 import {
   APIGatewayProxyEvent,
-  Context
+  APIGatewayProxyResult,
+  Context,
 } from 'https://deno.land/x/lambda/mod.ts';
 
 export async function handler(
   event: APIGatewayProxyEvent,
   context: Context
-) {
+): Promise<APIGatewayProxyResult> {
   return {
     statusCode: 200,
     body: `Welcome to deno ${Deno.version.deno} 🦕`,

--- a/example/api/version.ts
+++ b/example/api/version.ts
@@ -1,11 +1,11 @@
 import {
-  APIGatewayEventRequestContext,
-  APIGatewayEvent,
+  APIGatewayProxyEvent,
+  Context
 } from 'https://deno.land/x/lambda/mod.ts';
 
 export async function handler(
-  event: APIGatewayEvent,
-  context: APIGatewayEventRequestContext
+  event: APIGatewayProxyEvent,
+  context: Context
 ) {
   return {
     statusCode: 200,


### PR DESCRIPTION
Note: APIGatewayEvent is [deprecated](https://github.com/hayd/deno-lambda/blob/db2738c3bf31b38f98546863e00cc24f4045458a/runtime/types.d.ts#L94) and so APIGatewayProxyEvent should be preferred.

I also added the APIGatewayProxyResult type to the handler as I think this is
useful to have in the example - it will fail to compile if the returned
value is missing attributes.

APIGatewayEventRequestContext is available as event.requestContext, it's not the type of the
second argument for the handler. :)