### PR TITLE
docs: add note about now version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ If you're unfamiliar with now runtimes, please read the [runtime docs](https://z
 }
 ```
 
+Note: You need Now v17.x or above to use the above configuration.
+
 ```ts
 // api/hello.ts
 import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'https://deno.land/x/lambda/mod.ts';


### PR DESCRIPTION
This PR adds a note about now version in README.md because now v16.x doesn't seem handling the configuration in the doc correctly (and the error message looked very strange).